### PR TITLE
Fix string-to-boolean casting

### DIFF
--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -125,8 +125,13 @@ final class SerializedParameter
      */
     private function castToSchemaType($value, ?string $type)
     {
-        if (($type === CebeType::BOOLEAN) && is_scalar($value) && preg_match('#^(true|false)$#i', (string) $value)) {
-            return is_string($value) ? strtolower($value) === 'true' : (bool) $value;
+        if ($type === CebeType::BOOLEAN && is_scalar($value)) {
+            if (preg_match('#^(true|false)$#i', (string)$value)) {
+                return is_string($value) ? strtolower($value) === 'true' : (bool)$value;
+            }
+            if (preg_match('#^(0|1)$#i', (string)$value)) {
+                return (string)$value === '1';
+            }
         }
 
         if (


### PR DESCRIPTION
It is very common that boolean value casted to "0" or "1" value. And it is the industry-standard in PHP because it is how http_build_query() cast boolean. 
I faced with many such issues and have to disable validation or use artificial string in the specification when dealing with boolean flags in the GET parameters. 
So I create this small PR to fix this issue.